### PR TITLE
Added DICOM anonymization option

### DIFF
--- a/web/meta/templates/partials/actions.html
+++ b/web/meta/templates/partials/actions.html
@@ -60,6 +60,13 @@
               </label>
             </div>
             <div class="form-check">
+              <input class="form-check-input" type="radio" name="download-type" id="download-anon-dicom"
+                value="anon-dicom">
+              <label class="form-check-label" for="download-anon-dicom">
+                as Anonymized Dicom
+              </label>
+            </div>
+            <div class="form-check">
               <input class="form-check-input" type="radio" name="download-type" id="download-nifti" value="nifti">
               <label class="form-check-label" for="download-nifti">
                 as Nifti (experimental)


### PR DESCRIPTION
DICOM anonymization using dcmodify. I couldn't test this code.

Fixes #2 .

Please check the following before merge:
1. The location of dcmodify. I used '/dcmodify' like you are using '/movescu', but I don't know if it's correct. Of course, make sure that dcmodify is correctly installed. It's part of the DCMTK tools
2. If the tags that I selected for deletion are fine for the anonymization. See also [this thread](https://forum.dcmtk.org/viewtopic.php?t=1330).

The command created by the `create_dicom_anonymize_cmd` is very long because it contains all the paths of the exported images. This should be fine under posix (see [here](https://stackoverflow.com/questions/2381241/what-is-the-subprocess-popen-max-length-of-the-args-parameter) but if it doesn't work I can break it up into multiple commands.